### PR TITLE
Switch to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: true
     default: 'https://www.antlr.org/download/antlr-4.10.1-complete.jar'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
When using the action, the following message is displayed:

The following actions uses node12 which is deprecated and will be forced to run on node16: StoneMoe/setup-antlr4@v2, actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

This PR aims at fixing this: considering the node code used, it seems compatible with node16

Should fix https://github.com/StoneMoe/setup-antlr4/issues/2