### PR TITLE
Transition from Node 16 to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: true
     default: 'https://www.antlr.org/download/antlr-4.13.1-complete.jar'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Using the latest version of the workflow yields the following warning.
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: StoneMoe/setup-antlr4@v4.13.1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
I updated `action.yml` to use `node20` and tested it in a repository of mine which relies on this workflow. There seems to be no problem in running the action using Node 20 so I am opening this PR.